### PR TITLE
Add basic navigation layouts

### DIFF
--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -413,7 +413,6 @@
 			);
 			mainGroup = BFBB3C5524A2D5BE007FEFE8;
 			packageReferences = (
-				BFF469D224B68D3E00F5CA44 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = BFBB3C6324A2D5C2007FEFE8 /* Products */;
 			projectDirPath = "";
@@ -945,17 +944,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		BFF469D224B68D3E00F5CA44 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.39.2;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
 	};
 	rootObject = BFBB3C5624A2D5BE007FEFE8 /* Project object */;
 }

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF11463E24B613E70040691B /* Standard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11463D24B613E70040691B /* Standard.swift */; };
+		BF11463F24B613E70040691B /* Standard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11463D24B613E70040691B /* Standard.swift */; };
 		BF455EDB24B402120066FB1B /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF455EDA24B402120066FB1B /* Visibility.swift */; };
 		BF455EDC24B402120066FB1B /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF455EDA24B402120066FB1B /* Visibility.swift */; };
 		BF673F0424B4A51F00A97FF3 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF673F0324B4A51F00A97FF3 /* Account.swift */; };
@@ -82,6 +84,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BF11463D24B613E70040691B /* Standard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standard.swift; sourceTree = "<group>"; };
 		BF455EDA24B402120066FB1B /* Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visibility.swift; sourceTree = "<group>"; };
 		BF673EFF24B407E400A97FF3 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		BF673F0324B4A51F00A97FF3 /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
@@ -159,6 +162,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BF11463C24B613CC0040691B /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				BF11463D24B613E70040691B /* Standard.swift */,
+			);
+			path = Navigation;
+			sourceTree = "<group>";
+		};
 		BF455ED824B401830066FB1B /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -171,6 +182,7 @@
 		BF455ED924B401860066FB1B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				BF11463C24B613CC0040691B /* Navigation */,
 				BFBB3C5C24A2D5BF007FEFE8 /* ContentView.swift */,
 			);
 			path = Components;
@@ -493,6 +505,7 @@
 			files = (
 				BF673F2224B4CCEE00A97FF3 /* AttachmentType.swift in Sources */,
 				FA48238624B46A860095E415 /* Field.swift in Sources */,
+				BF11463E24B613E70040691B /* Standard.swift in Sources */,
 				BFBB3C8624A2D5C2007FEFE8 /* ContentView.swift in Sources */,
 				BF673F0D24B4BD2800A97FF3 /* Tag.swift in Sources */,
 				FAE4B25F24B4EE83000B5405 /* Announcement.swift in Sources */,
@@ -525,6 +538,7 @@
 			files = (
 				BF673F2324B4CCEE00A97FF3 /* AttachmentType.swift in Sources */,
 				FA48238724B46A860095E415 /* Field.swift in Sources */,
+				BF11463F24B613E70040691B /* Standard.swift in Sources */,
 				BFBB3C8724A2D5C2007FEFE8 /* ContentView.swift in Sources */,
 				BF673F0E24B4BD2800A97FF3 /* Tag.swift in Sources */,
 				FAE4B26024B4EE83000B5405 /* Announcement.swift in Sources */,

--- a/Hyperspace.xcodeproj/project.pbxproj
+++ b/Hyperspace.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF014B0E24B67CBE002C5812 /* Compact.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF014B0D24B67CBE002C5812 /* Compact.swift */; };
+		BF014B0F24B67CBE002C5812 /* Compact.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF014B0D24B67CBE002C5812 /* Compact.swift */; };
 		BF11463E24B613E70040691B /* Standard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11463D24B613E70040691B /* Standard.swift */; };
 		BF11463F24B613E70040691B /* Standard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11463D24B613E70040691B /* Standard.swift */; };
 		BF455EDB24B402120066FB1B /* Visibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF455EDA24B402120066FB1B /* Visibility.swift */; };
@@ -47,7 +49,6 @@
 		BFBB3C8724A2D5C2007FEFE8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBB3C5C24A2D5BF007FEFE8 /* ContentView.swift */; };
 		BFBB3C8824A2D5C2007FEFE8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFBB3C5D24A2D5C2007FEFE8 /* Assets.xcassets */; };
 		BFBB3C8924A2D5C2007FEFE8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFBB3C5D24A2D5C2007FEFE8 /* Assets.xcassets */; };
-		BFF0845824B3A11000B52BCB /* SwiftLintFramework in Frameworks */ = {isa = PBXBuildFile; productRef = BFF0845724B3A11000B52BCB /* SwiftLintFramework */; };
 		FA48238624B46A860095E415 /* Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA48238524B46A860095E415 /* Field.swift */; };
 		FA48238724B46A860095E415 /* Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA48238524B46A860095E415 /* Field.swift */; };
 		FA48238924B46E580095E415 /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA48238824B46E580095E415 /* Emoji.swift */; };
@@ -84,6 +85,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BF014B0D24B67CBE002C5812 /* Compact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compact.swift; sourceTree = "<group>"; };
 		BF11463D24B613E70040691B /* Standard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standard.swift; sourceTree = "<group>"; };
 		BF455EDA24B402120066FB1B /* Visibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visibility.swift; sourceTree = "<group>"; };
 		BF673EFF24B407E400A97FF3 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -141,7 +143,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFF0845824B3A11000B52BCB /* SwiftLintFramework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -166,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				BF11463D24B613E70040691B /* Standard.swift */,
+				BF014B0D24B67CBE002C5812 /* Compact.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -335,7 +337,6 @@
 			);
 			name = macOS;
 			packageProductDependencies = (
-				BFF0845724B3A11000B52BCB /* SwiftLintFramework */,
 			);
 			productName = macOS;
 			productReference = BFBB3C6A24A2D5C2007FEFE8 /* Hyperspace.app */;
@@ -412,7 +413,7 @@
 			);
 			mainGroup = BFBB3C5524A2D5BE007FEFE8;
 			packageReferences = (
-				BFF0845624B3A11000B52BCB /* XCRemoteSwiftPackageReference "SwiftLint" */,
+				BFF469D224B68D3E00F5CA44 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = BFBB3C6324A2D5C2007FEFE8 /* Products */;
 			projectDirPath = "";
@@ -513,6 +514,7 @@
 				BF673F1624B4C30A00A97FF3 /* CardType.swift in Sources */,
 				FAE4B26524B4F532000B5405 /* Relationship.swift in Sources */,
 				FAE4B26224B4F1FA000B5405 /* AnnouncementReaction.swift in Sources */,
+				BF014B0E24B67CBE002C5812 /* Compact.swift in Sources */,
 				BF673F1024B4BDA300A97FF3 /* History.swift in Sources */,
 				FA48238924B46E580095E415 /* Emoji.swift in Sources */,
 				FAE4B25C24B4ABFA000B5405 /* Status.swift in Sources */,
@@ -546,6 +548,7 @@
 				BF673F1724B4C30A00A97FF3 /* CardType.swift in Sources */,
 				FAE4B26624B4F532000B5405 /* Relationship.swift in Sources */,
 				FAE4B26324B4F1FA000B5405 /* AnnouncementReaction.swift in Sources */,
+				BF014B0F24B67CBE002C5812 /* Compact.swift in Sources */,
 				BF673F1124B4BDA300A97FF3 /* History.swift in Sources */,
 				FA48238A24B46E580095E415 /* Emoji.swift in Sources */,
 				FAE4B25D24B4ABFA000B5405 /* Status.swift in Sources */,
@@ -722,11 +725,13 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.marquiskurt.Hyperspace;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.marquiskurt.hyperspace-swiftui";
 				PRODUCT_NAME = Hyperspace;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -744,12 +749,13 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.marquiskurt.Hyperspace;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.marquiskurt.hyperspace-swiftui";
 				PRODUCT_NAME = Hyperspace;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 arm64e armv7 armv7s";
 			};
 			name = Release;
 		};
@@ -941,7 +947,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		BFF0845624B3A11000B52BCB /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+		BFF469D224B68D3E00F5CA44 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/SwiftLint";
 			requirement = {
@@ -950,14 +956,6 @@
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		BFF0845724B3A11000B52BCB /* SwiftLintFramework */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BFF0845624B3A11000B52BCB /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = SwiftLintFramework;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = BFBB3C5624A2D5BE007FEFE8 /* Project object */;
 }

--- a/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.718",
+          "green" : "0.227",
+          "red" : "0.404"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Shared/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.383",
+          "red" : "0.605"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Shared/Components/ContentView.swift
+++ b/Shared/Components/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
                 .frame(minWidth: 500, minHeight: 300)
             #else
             if horizontalSizeClass == .compact {
-
+                CompactNavigationLayout()
             } else {
                 StandardNavigationLayout()
             }

--- a/Shared/Components/ContentView.swift
+++ b/Shared/Components/ContentView.swift
@@ -9,7 +9,11 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello, world!").padding()
+        Group {
+            #if os(macOS)
+            StandardNavigationLayout()
+            #endif
+        }
     }
 }
 

--- a/Shared/Components/ContentView.swift
+++ b/Shared/Components/ContentView.swift
@@ -7,12 +7,25 @@
 
 import SwiftUI
 
+/// The structured view for the app
 struct ContentView: View {
+
+    #if os(iOS)
+    /// Determines whether the device is compact or standard
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    #endif
+
     var body: some View {
         Group {
             #if os(macOS)
             StandardNavigationLayout()
                 .frame(minWidth: 500, minHeight: 300)
+            #else
+            if horizontalSizeClass == .compact {
+
+            } else {
+                StandardNavigationLayout()
+            }
             #endif
         }
     }

--- a/Shared/Components/ContentView.swift
+++ b/Shared/Components/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
         Group {
             #if os(macOS)
             StandardNavigationLayout()
-                .frame(minWidth: 500, minHeight: 300)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             #else
             if horizontalSizeClass == .compact {
                 CompactNavigationLayout()

--- a/Shared/Components/ContentView.swift
+++ b/Shared/Components/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
         Group {
             #if os(macOS)
             StandardNavigationLayout()
+                .frame(minWidth: 500, minHeight: 300)
             #endif
         }
     }

--- a/Shared/Components/Navigation/Compact.swift
+++ b/Shared/Components/Navigation/Compact.swift
@@ -1,6 +1,6 @@
 //
 //  Compact.swift
-//  Hyperspace
+//  Codename Starlight
 //
 //  Created by Marquis Kurt on 7/8/20.
 //

--- a/Shared/Components/Navigation/Compact.swift
+++ b/Shared/Components/Navigation/Compact.swift
@@ -1,0 +1,51 @@
+//
+//  Compact.swift
+//  Hyperspace
+//
+//  Created by Marquis Kurt on 7/8/20.
+//
+
+import SwiftUI
+
+struct CompactNavigationLayout: View {
+    var body: some View {
+        TabView {
+            VStack {
+                Text("Home Feed View")
+                    .padding()
+            }.tabItem {
+                Label("Home", systemImage: "house")
+            }
+            VStack {
+                Text("Network View")
+                    .padding()
+            }.tabItem {
+                Label("Network", systemImage: "network")
+            }
+            VStack {
+                Text("Explore View")
+                    .padding()
+            }.tabItem {
+                Label("Explore", systemImage: "magnifyingglass")
+            }
+            VStack {
+                Text("Personal View")
+                    .padding()
+            }.tabItem {
+                Label("You", systemImage: "person.circle")
+            }
+            VStack {
+                Text("Settings View")
+                    .padding()
+            }.tabItem {
+                Label("Settings", systemImage: "gear")
+            }
+        }.tabViewStyle(DefaultTabViewStyle())
+    }
+}
+
+struct Compact_Previews: PreviewProvider {
+    static var previews: some View {
+        CompactNavigationLayout()
+    }
+}

--- a/Shared/Components/Navigation/Standard.swift
+++ b/Shared/Components/Navigation/Standard.swift
@@ -35,10 +35,15 @@ struct StandardNavigationLayout: View {
             NavigationView {
                 VStack {
                     #if os(macOS)
-                    TextField("Search...", text: $searchText)
+                    HStack {
+                        TextField("Search...", text: self.$searchText)
+                            .cornerRadius(4)
+                    }
                         .padding()
-                        .padding(.trailing, 8)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .onTapGesture {
+                            self.selection = [.searchResults]
+                        }
                     #endif
 
                     List(selection: $selection) {
@@ -144,15 +149,14 @@ struct StandardNavigationLayout: View {
                 }
 
                 ToolbarItem {
-                    Button(action: {}) {
+                    Button(action: selectNotifications) {
                         Image(systemName: "bell")
                     }
                     .help("View your notifications.")
-                    .tag(NavigationViews.notifications)
                 }
 
                 ToolbarItem {
-                    Button(action: {}) {
+                    Button(action: selectNotifications) {
                         Image(systemName: "square.and.pencil")
                     }.help("Write a new post.")
                 }
@@ -169,6 +173,11 @@ struct StandardNavigationLayout: View {
                 NSSplitViewController.toggleSidebar(_:)
             ), with: nil)
         #endif
+    }
+
+    /// Change the current view selection to the notifications view.
+    private func selectNotifications() {
+        self.selection = [.notifications]
     }
 }
 

--- a/Shared/Components/Navigation/Standard.swift
+++ b/Shared/Components/Navigation/Standard.swift
@@ -10,59 +10,151 @@ import SwiftUI
 /// The navigation layout on bigger devices such as iPads and Macs.
 struct StandardNavigationLayout: View {
 
+    /// An enumeration of the different timeline pages
+    enum NavigationViews {
+        case home
+        case local
+        case `public`
+        case messages
+        case announcements
+        case activity
+        case recommended
+        case searchResults
+        case notifications
+    }
+
     /// The search bar's current text input.
     @State private var searchText = ""
+
+    /// The current navigation selection
+    @State private var selection: Set<NavigationViews> = [.home]
 
     /// The primary view.
     var body: some View {
         HStack {
             NavigationView {
-                VStack(alignment: .leading) {
-
+                VStack {
                     #if os(macOS)
                     TextField("Search...", text: $searchText)
-                        .padding(.horizontal)
-                        .cornerRadius(4)
+                        .padding()
+                        .padding(.trailing, 8)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                     #endif
 
-                    List {
-                        NavigationLink(
-                            destination:
-                                Text("Home timeline")
+                    List(selection: $selection) {
+                        Section {
+                            NavigationLink(
+                                destination:
+                                    Text("Home timeline")
+                                        .padding()
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity),
+                                label: {
+                                    Label("Home", systemImage: "house")
+                                })
+                                .accessibility(label: Text("Home"))
+                                .tag(NavigationViews.home)
+                            NavigationLink(
+                                destination:
+                                    Text("Local timeline")
+                                        .padding()
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity),
+                                label: {
+                                    Label("Local", systemImage: "building.2")
+                                })
+                                .accessibility(label: Text("Local"))
+                                .tag(NavigationViews.local)
+                            NavigationLink(
+                                destination:
+                                    Text("Public timeline")
+                                        .padding()
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity),
+                                label: {
+                                    Label("Public", systemImage: "globe")
+                                })
+                                .accessibility(label: Text("Public"))
+                                .tag(NavigationViews.public)
+                            NavigationLink(
+                                destination:
+                                    Text("Messages")
+                                        .padding()
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity),
+                                label: {
+                                    Label("Messages", systemImage: "quote.bubble")
+                                })
+                                .accessibility(label: Text("Messages"))
+                                .tag(NavigationViews.messages)
+                            #if os(iOS)
+                            NavigationLink(
+                                destination:
+                                    Text("Search")
+                                        .padding()
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity),
+                                label: {
+                                    Label("Search", systemImage: "magnifyingglass")
+                                })
+                                .accessibility(label: Text("Search"))
+                                .tag(NavigationViews.searchResults)
+                            #endif
+                        }
+
+                        Section {
+                            NavigationLink(
+                                destination:
+                                    Text("Announcements")
                                     .padding()
                                     .frame(maxWidth: .infinity, maxHeight: .infinity),
-                            label: {
-                                Label("Home", systemImage: "house")
-                            })
-                        NavigationLink(
-                            destination:
-                                Text("Local timeline")
+                                label: {
+                                    Label("Announcements", systemImage: "megaphone")
+                                })
+                                .accessibility(label: Text("Announcements"))
+                                .tag(NavigationViews.announcements)
+                            NavigationLink(
+                                destination:
+                                    Text("Activity")
                                     .padding()
                                     .frame(maxWidth: .infinity, maxHeight: .infinity),
-                            label: {
-                                Label("Local", systemImage: "building.2")
-                            })
-                        NavigationLink(
-                            destination:
-                                Text("Public timeline")
+                                label: {
+                                    Label("Activity", systemImage: "flame")
+                                })
+                                .accessibility(label: Text("Activity"))
+                                .tag(NavigationViews.activity)
+                            NavigationLink(
+                                destination:
+                                    Text("Recommended")
                                     .padding()
                                     .frame(maxWidth: .infinity, maxHeight: .infinity),
-                            label: {
-                                Label("Public", systemImage: "globe")
-                            })
+                                label: {
+                                    Label("Recommended", systemImage: "person.2")
+                                })
+                                .accessibility(label: Text("Recommended"))
+                                .tag(NavigationViews.recommended)
+                        }
                     }
                     .listStyle(SidebarListStyle())
-                    .frame(maxWidth: .infinity)
+                    .frame(minWidth: 170, maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(minWidth: 170, idealWidth: 180, maxWidth: .infinity)
+                .frame(minWidth: 170, idealWidth: 180, maxWidth: .infinity, maxHeight: .infinity)
             }
             .toolbar {
                 #if os(macOS)
                 ToolbarItem(placement: .navigation) {
                     Button(action: toggleSidebar) {
                         Image(systemName: "sidebar.left")
+                    }.help("Show or hide the sidebar.")
+                }
+
+                ToolbarItem {
+                    Button(action: {}) {
+                        Image(systemName: "bell")
                     }
+                    .help("View your notifications.")
+                    .tag(NavigationViews.notifications)
+                }
+
+                ToolbarItem {
+                    Button(action: {}) {
+                        Image(systemName: "square.and.pencil")
+                    }.help("Write a new post.")
                 }
                 #endif
             }

--- a/Shared/Components/Navigation/Standard.swift
+++ b/Shared/Components/Navigation/Standard.swift
@@ -1,0 +1,53 @@
+//
+//  Standard.swift
+//  Codename Starlight
+//
+//  Created by Marquis Kurt on 7/8/20.
+//
+
+import SwiftUI
+
+struct StandardNavigationLayout: View {
+    var body: some View {
+        HStack {
+            NavigationView {
+                VStack(alignment: .leading) {
+                    List {
+                        NavigationLink(
+                            destination:
+                                /*@START_MENU_TOKEN@*/Text("Destination")/*@END_MENU_TOKEN@*/.padding(),
+                            label: {
+                                Label("Home", systemImage: "house")
+                            })
+                        Text("G")
+                    }.listStyle(SidebarListStyle())
+                }
+            }
+            .toolbar {
+                #if os(macOS)
+                ToolbarItem(placement: .navigation) {
+                    Button(action: toggleSidebar) {
+                        Image(systemName: "sidebar.left")
+                    }
+                }
+                #endif
+            }
+        }
+    }
+    
+    /// Toggle the sidebar in macOS.
+    private func toggleSidebar() {
+        #if os(macOS)
+        NSApp.keyWindow?.firstResponder?.tryToPerform(
+            #selector(
+                NSSplitViewController.toggleSidebar(_:)
+            ), with: nil)
+        #endif
+    }
+}
+
+struct Standard_Previews: PreviewProvider {
+    static var previews: some View {
+        StandardNavigationLayout()
+    }
+}

--- a/Shared/Components/Navigation/Standard.swift
+++ b/Shared/Components/Navigation/Standard.swift
@@ -7,21 +7,55 @@
 
 import SwiftUI
 
+/// The navigation layout on bigger devices such as iPads and Macs.
 struct StandardNavigationLayout: View {
+
+    /// The search bar's current text input.
+    @State private var searchText = ""
+
+    /// The primary view.
     var body: some View {
         HStack {
             NavigationView {
                 VStack(alignment: .leading) {
+
+                    #if os(macOS)
+                    TextField("Search...", text: $searchText)
+                        .padding(.horizontal)
+                        .cornerRadius(4)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    #endif
+
                     List {
                         NavigationLink(
                             destination:
-                                /*@START_MENU_TOKEN@*/Text("Destination")/*@END_MENU_TOKEN@*/.padding(),
+                                Text("Home timeline")
+                                    .padding()
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity),
                             label: {
                                 Label("Home", systemImage: "house")
                             })
-                        Text("G")
-                    }.listStyle(SidebarListStyle())
+                        NavigationLink(
+                            destination:
+                                Text("Local timeline")
+                                    .padding()
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity),
+                            label: {
+                                Label("Local", systemImage: "building.2")
+                            })
+                        NavigationLink(
+                            destination:
+                                Text("Public timeline")
+                                    .padding()
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity),
+                            label: {
+                                Label("Public", systemImage: "globe")
+                            })
+                    }
+                    .listStyle(SidebarListStyle())
+                    .frame(maxWidth: .infinity)
                 }
+                .frame(minWidth: 170, idealWidth: 180, maxWidth: .infinity)
             }
             .toolbar {
                 #if os(macOS)
@@ -34,7 +68,7 @@ struct StandardNavigationLayout: View {
             }
         }
     }
-    
+
     /// Toggle the sidebar in macOS.
     private func toggleSidebar() {
         #if os(macOS)


### PR DESCRIPTION
**Changes Overview**  
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->
- Adds a basic navigation layout for the macOS/iPadOS and iOS apps
- Removes SwiftLint as a Swift package dependency (install via Homebrew instead)
- Adds app's accent color

**Does this PR fix, close, or implement any issues?**  
- [ ] This PR closes, fixes, or implements the following issues.

<!-- List any issues that this pull request may close or contribute to. Make sure you follow the proper syntax for referencing an issue.

Examples:

- Implements #0
- Closes HyperspaceDev/starlight#0
- Contributes to #0
 -->

<!-- If the following is a release check, uncomment the following line. -->
<!-- - [x] This is a release check. -->

**Pending for review**  
@hyperspacedev/swiftui 

<table>
<tr>
<td>
<img width="865" alt="Screen Shot 2020-07-08 at 9 26 53 PM" src="https://user-images.githubusercontent.com/13445064/87054225-df2f5180-c1d0-11ea-81b1-fa3f67fd7a19.png">
</td>
<td>

![Simulator Screen Shot - iPhone 11 - 2020-07-08 at 21 25 33](https://user-images.githubusercontent.com/13445064/87054271-ec4c4080-c1d0-11ea-9530-9f70b57ffede.png)

</td>
</tr>
</table>
