### PR TITLE
Remove nested navigation views for standard layouts

### DIFF
--- a/Shared/Components/Navigation/Compact.swift
+++ b/Shared/Components/Navigation/Compact.swift
@@ -24,7 +24,9 @@ struct CompactNavigationLayout: View {
             .tabItem {
                 Label("tabs.explore", systemImage: "magnifyingglass")
             }
-            SettingsView()
+            NavigationView {
+                SettingsView()
+            }
             .tabItem {
                 Label("tabs.prefs", systemImage: "gear")
             }

--- a/Shared/Components/Navigation/Standard.swift
+++ b/Shared/Components/Navigation/Standard.swift
@@ -70,12 +70,14 @@ struct StandardNavigationLayout: View {
                 }
                 .frame(minWidth: 170, idealWidth: 180, maxWidth: .infinity, maxHeight: .infinity)
 
+                // This view is used to instantiate the split column, which will be taken on in other children.
                 Group {
                     StackedLabel(systemName: "tray.fill", title: "masterdetail.list.title") {
                         Text("masterdetail.list.subtitle")
                     }
                 }
 
+                // This view is used to instantiate the detaul view, thus making the full split-view container.
                 Group {
                     StackedLabel(systemName: "newspaper", title: "timelines.detail.title") {
                         Text("timelines.detail.subtitle")

--- a/Shared/Components/Navigation/Standard.swift
+++ b/Shared/Components/Navigation/Standard.swift
@@ -45,7 +45,7 @@ struct StandardNavigationLayout: View {
                             Label("tabs.home", systemImage: "house")
                         }
                         .tag(NavigationViews.home)
-                        NavigationLink(destination: NetworkView()) {
+                        NavigationLink(destination: TimelineMasterDetailView(scope: .network(localOnly: true))) {
                             Label("tabs.network", systemImage: "network")
                         }
                         .tag(NavigationViews.network)
@@ -63,9 +63,24 @@ struct StandardNavigationLayout: View {
                         #endif
                     }
                     .listStyle(.sidebar)
+                    #if os(iOS)
+                    .navigationTitle("Starlight")
+                    #endif
                     .frame(minWidth: 170, maxWidth: .infinity, maxHeight: .infinity)
                 }
                 .frame(minWidth: 170, idealWidth: 180, maxWidth: .infinity, maxHeight: .infinity)
+
+                Group {
+                    StackedLabel(systemName: "tray.fill", title: "masterdetail.list.title") {
+                        Text("masterdetail.list.subtitle")
+                    }
+                }
+
+                Group {
+                    StackedLabel(systemName: "newspaper", title: "timelines.detail.title") {
+                        Text("timelines.detail.subtitle")
+                    }
+                }
             }
             .onAppear(perform: loadData)
             .refreshable{ loadData() }

--- a/Shared/Components/Pages/SettingsView.swift
+++ b/Shared/Components/Pages/SettingsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 /// The main view for adjusting settings.
+/// - Important: This view is _not_ wrapped in a NavigationView. For areas that need it, please wrap the SettingsView in a NavigationView.
 struct SettingsView: View {
     
     private enum SettingsKeys {
@@ -17,9 +18,14 @@ struct SettingsView: View {
     }
     
     @State private var selection: Set<SettingsKeys> = [.general]
+
+    #if os(iOS)
+    /// Determines whether the device is compact or standard
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    #endif
     
     var body: some View {
-        NavigationView {
+        Group {
             List(selection: $selection) {
                 NavigationLink(destination: Text("Fediverse account settings").navigationTitle("Fediverse Account")) {
                     #if os(iOS)
@@ -45,8 +51,8 @@ struct SettingsView: View {
                 #endif
             }
             #if os(iOS)
-            .listStyle(.insetGrouped)
             .navigationBarTitle("tabs.prefs")
+            .listStyle(.insetGrouped)
             #elseif os(macOS)
             .listStyle(.sidebar)
             #endif

--- a/Shared/Components/Pages/TimelineMasterDetailView.swift
+++ b/Shared/Components/Pages/TimelineMasterDetailView.swift
@@ -15,10 +15,10 @@ struct TimelineMasterDetailView: View {
     
     /// The body of the view.
     var body: some View {
-        NavigationView {
-            TimelineViewable(scope: scope) { statuses in
-                timeline(statuses)
-            }
+        TimelineViewable(scope: scope) { statuses in
+            // timeline(statuses)
+            TimelineMasterDetailList(stream: statuses)
+//            TimelineMasterDetailPrompt(stream: statuses)
         }
     }
     
@@ -46,37 +46,50 @@ struct TimelineMasterDetailView: View {
     
     private func timeline(_ statuses: [Status]?) -> some View {
         Group {
-            List {
-                if let stream = statuses {
-                    ForEach(stream, id: \.id) { post in
-                        NavigationLink(destination: PostDetailView(post: post)) {
-                            PostView(post: post, truncate: true)
-                        }
+            TimelineMasterDetailList(stream: statuses)
+            TimelineMasterDetailPrompt(stream: statuses)
+        }
+    }
+}
+
+struct TimelineMasterDetailList: View {
+    var stream: [Status]?
+    var body: some View {
+        List {
+            if let posts = stream {
+                ForEach(posts, id: \.id) { post in
+                    NavigationLink(destination: PostDetailView(post: post)) {
+                        PostView(post: post, truncate: true)
                     }
-                }
-            }
-            #if os(macOS)
-            .listStyle(.bordered(alternatesRowBackgrounds: true))
-            .frame(minWidth: 400)
-            #else
-            .listStyle(.insetGrouped)
-            #endif
-            
-            if statuses?.isEmpty == true {
-                StackedLabel(systemName: "tray", title: "timelines.empty") {
-                    Button(action: {}) {
-                        Text("actions.reload")
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-            } else {
-                StackedLabel(systemName: "newspaper", title: "timelines.detail.title") {
-                    Text("timelines.detail.subtitle")
                 }
             }
         }
+        #if os(macOS)
+        .listStyle(.bordered(alternatesRowBackgrounds: true))
+        .frame(minWidth: 400)
+        #else
+        .listStyle(.automatic)
+        .navigationBarTitleDisplayMode(.large)
+        #endif
     }
-        
+}
+
+struct TimelineMasterDetailPrompt: View {
+    var stream: [Status]?
+    var body: some View {
+        if stream?.isEmpty == true {
+            StackedLabel(systemName: "tray", title: "timelines.empty") {
+                Button(action: {}) {
+                    Text("actions.reload")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        } else {
+            StackedLabel(systemName: "newspaper", title: "timelines.detail.title") {
+                Text("timelines.detail.subtitle")
+            }
+        }
+    }
 }
 
 struct TimelineView_Previews: PreviewProvider {

--- a/Shared/Components/Pages/TimelineMasterDetailView.swift
+++ b/Shared/Components/Pages/TimelineMasterDetailView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import Chica
 
 /// A view that displays posts and threads in a master-detail style.
+///
+/// It is recommended that this view be used in split-view containers.
 struct TimelineMasterDetailView: View {
     
     @State var scope: TimelineViewableScope
@@ -16,9 +18,7 @@ struct TimelineMasterDetailView: View {
     /// The body of the view.
     var body: some View {
         TimelineViewable(scope: scope) { statuses in
-            // timeline(statuses)
-            TimelineMasterDetailList(stream: statuses)
-//            TimelineMasterDetailPrompt(stream: statuses)
+            timeline(statuses)
         }
     }
     
@@ -45,13 +45,12 @@ struct TimelineMasterDetailView: View {
     }
     
     private func timeline(_ statuses: [Status]?) -> some View {
-        Group {
-            TimelineMasterDetailList(stream: statuses)
-            TimelineMasterDetailPrompt(stream: statuses)
-        }
+        TimelineMasterDetailList(stream: statuses)
+            .frame(idealWidth: 450)
     }
 }
 
+/// A view that displays a list of posts that will push the details of a post onto the stack.
 struct TimelineMasterDetailList: View {
     var stream: [Status]?
     var body: some View {
@@ -71,24 +70,6 @@ struct TimelineMasterDetailList: View {
         .listStyle(.automatic)
         .navigationBarTitleDisplayMode(.large)
         #endif
-    }
-}
-
-struct TimelineMasterDetailPrompt: View {
-    var stream: [Status]?
-    var body: some View {
-        if stream?.isEmpty == true {
-            StackedLabel(systemName: "tray", title: "timelines.empty") {
-                Button(action: {}) {
-                    Text("actions.reload")
-                }
-                .buttonStyle(.borderedProminent)
-            }
-        } else {
-            StackedLabel(systemName: "newspaper", title: "timelines.detail.title") {
-                Text("timelines.detail.subtitle")
-            }
-        }
     }
 }
 

--- a/Shared/StarlightApp.swift
+++ b/Shared/StarlightApp.swift
@@ -22,7 +22,9 @@ struct StarlightApp: App {
         
         #if os(macOS)
         Settings {
-            SettingsView()
+            NavigationView {
+                SettingsView()
+            }
         }
         #endif
     }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -22,6 +22,10 @@
 "tabs.messages" = "Messages";
 "tabs.prefs" = "Settings";
 
+// MARK: - Master Detail Views
+"masterdetail.list.title" = "Select a Page";
+"masterdetail.list.subtitle" = "Select a page from the sidebar to view its contents here.";
+
 // MARK: - Timelines
 "timelines.updatediff" = "Last updated %@ ago";
 "timelines.updatediff.started" = "Just updated now";


### PR DESCRIPTION
**Changes Overview**  
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->
- Unwraps `TimelineMasterDetailView` to remove nested navigation views
- Refactors `Standard` navigation layout to support split columns
- Unwraps `SettingsView` to remove nested navigation view
- Wraps `SettingsView` in navigation views where necessary

**Does this PR fix, close, or implement any issues?**  
- [x] This PR closes, fixes, or implements the following issues.

<!-- List any issues that this pull request may close or contribute to. Make sure you follow the proper syntax for referencing an issue.

Examples:

- Implements #0
- Closes HyperspaceDev/starlight#0
- Contributes to #0
 -->

- Fixes #21

<!-- If the following is a release check, uncomment the following line. -->
<!-- - [x] This is a release check. -->

**Pending for review**  
@hyperspacedev/swift-ui